### PR TITLE
Fix weird toolbar styles in demo

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -73,7 +73,8 @@ module.exports = function ( grunt ) {
 				env: { debug: false },
 				pathPrefix: '../',
 				i18n: [ 'i18n/', 'lib/ve/i18n/', 'lib/ve/lib/oojs-ui/i18n/' ],
-				indent: '\t\t'
+				indent: '\t\t',
+				dir: 'ltr'
 			},
 			test: {
 				targetFile: 'tests/index.html',

--- a/demo/LL.html
+++ b/demo/LL.html
@@ -13,30 +13,18 @@
 		<title>LL two-way parallel translation</title>
 
 		<!-- oojs-ui-apex -->
-		<link rel=stylesheet href="../lib/ve/lib/oojs-ui/oojs-ui-apex.css" class="stylesheet-ltr stylesheet-read">
-		<link rel=stylesheet href="../lib/ve/lib/oojs-ui/oojs-ui-apex.rtl.css" class="stylesheet-rtl stylesheet-read">
-		<link rel=stylesheet href="../lib/ve/lib/oojs-ui/oojs-ui-apex-icons-alerts.css" class="stylesheet-ltr stylesheet-read">
-		<link rel=stylesheet href="../lib/ve/lib/oojs-ui/oojs-ui-apex-icons-alerts.rtl.css" class="stylesheet-rtl stylesheet-read">
-		<link rel=stylesheet href="../lib/ve/lib/oojs-ui/oojs-ui-apex-icons-content.css" class="stylesheet-ltr stylesheet-read">
-		<link rel=stylesheet href="../lib/ve/lib/oojs-ui/oojs-ui-apex-icons-content.rtl.css" class="stylesheet-rtl stylesheet-read">
-		<link rel=stylesheet href="../lib/ve/lib/oojs-ui/oojs-ui-apex-icons-interactions.css" class="stylesheet-ltr stylesheet-read">
-		<link rel=stylesheet href="../lib/ve/lib/oojs-ui/oojs-ui-apex-icons-interactions.rtl.css" class="stylesheet-rtl stylesheet-read">
-		<link rel=stylesheet href="../lib/ve/lib/oojs-ui/oojs-ui-apex-icons-layout.css" class="stylesheet-ltr stylesheet-read">
-		<link rel=stylesheet href="../lib/ve/lib/oojs-ui/oojs-ui-apex-icons-layout.rtl.css" class="stylesheet-rtl stylesheet-read">
-		<link rel=stylesheet href="../lib/ve/lib/oojs-ui/oojs-ui-apex-icons-moderation.css" class="stylesheet-ltr stylesheet-read">
-		<link rel=stylesheet href="../lib/ve/lib/oojs-ui/oojs-ui-apex-icons-moderation.rtl.css" class="stylesheet-rtl stylesheet-read">
-		<link rel=stylesheet href="../lib/ve/lib/oojs-ui/oojs-ui-apex-icons-movement.css" class="stylesheet-ltr stylesheet-read">
-		<link rel=stylesheet href="../lib/ve/lib/oojs-ui/oojs-ui-apex-icons-movement.rtl.css" class="stylesheet-rtl stylesheet-read">
-		<link rel=stylesheet href="../lib/ve/lib/oojs-ui/oojs-ui-apex-icons-user.css" class="stylesheet-ltr stylesheet-read">
-		<link rel=stylesheet href="../lib/ve/lib/oojs-ui/oojs-ui-apex-icons-user.rtl.css" class="stylesheet-rtl stylesheet-read">
-		<link rel=stylesheet href="../lib/ve/lib/oojs-ui/oojs-ui-apex-icons-editing-core.css" class="stylesheet-ltr stylesheet-read">
-		<link rel=stylesheet href="../lib/ve/lib/oojs-ui/oojs-ui-apex-icons-editing-core.rtl.css" class="stylesheet-rtl stylesheet-read">
-		<link rel=stylesheet href="../lib/ve/lib/oojs-ui/oojs-ui-apex-icons-editing-advanced.css" class="stylesheet-ltr stylesheet-read">
-		<link rel=stylesheet href="../lib/ve/lib/oojs-ui/oojs-ui-apex-icons-editing-advanced.rtl.css" class="stylesheet-rtl stylesheet-read">
-		<link rel=stylesheet href="../lib/ve/lib/oojs-ui/oojs-ui-apex-icons-editing-styling.css" class="stylesheet-ltr stylesheet-read">
-		<link rel=stylesheet href="../lib/ve/lib/oojs-ui/oojs-ui-apex-icons-editing-styling.rtl.css" class="stylesheet-rtl stylesheet-read">
-		<link rel=stylesheet href="../lib/ve/lib/oojs-ui/oojs-ui-apex-icons-editing-list.css" class="stylesheet-ltr stylesheet-read">
-		<link rel=stylesheet href="../lib/ve/lib/oojs-ui/oojs-ui-apex-icons-editing-list.rtl.css" class="stylesheet-rtl stylesheet-read">
+		<link rel=stylesheet href="../lib/ve/lib/oojs-ui/oojs-ui-apex.css" class="stylesheet-read">
+		<link rel=stylesheet href="../lib/ve/lib/oojs-ui/oojs-ui-apex-icons-alerts.css" class="stylesheet-read">
+		<link rel=stylesheet href="../lib/ve/lib/oojs-ui/oojs-ui-apex-icons-content.css" class="stylesheet-read">
+		<link rel=stylesheet href="../lib/ve/lib/oojs-ui/oojs-ui-apex-icons-interactions.css" class="stylesheet-read">
+		<link rel=stylesheet href="../lib/ve/lib/oojs-ui/oojs-ui-apex-icons-layout.css" class="stylesheet-read">
+		<link rel=stylesheet href="../lib/ve/lib/oojs-ui/oojs-ui-apex-icons-moderation.css" class="stylesheet-read">
+		<link rel=stylesheet href="../lib/ve/lib/oojs-ui/oojs-ui-apex-icons-movement.css" class="stylesheet-read">
+		<link rel=stylesheet href="../lib/ve/lib/oojs-ui/oojs-ui-apex-icons-user.css" class="stylesheet-read">
+		<link rel=stylesheet href="../lib/ve/lib/oojs-ui/oojs-ui-apex-icons-editing-core.css" class="stylesheet-read">
+		<link rel=stylesheet href="../lib/ve/lib/oojs-ui/oojs-ui-apex-icons-editing-advanced.css" class="stylesheet-read">
+		<link rel=stylesheet href="../lib/ve/lib/oojs-ui/oojs-ui-apex-icons-editing-styling.css" class="stylesheet-read">
+		<link rel=stylesheet href="../lib/ve/lib/oojs-ui/oojs-ui-apex-icons-editing-list.css" class="stylesheet-read">
 
 		<!-- visualEditor.core.view -->
 		<link rel=stylesheet href="../lib/ve/src/ce/styles/nodes/ve.ce.FocusableNode.css" class="stylesheet-ve">
@@ -103,7 +91,7 @@
 		<link rel=stylesheet href="../lib/ve/demos/ve/demo.minimal.css">
 		<link rel=stylesheet href="demo.ll.css">
 	</head>
-	<body dir="undefined">
+	<body dir="ltr">
 		<h1 style="text-align: center">Utterly bleeding edge demo (loads slowly)</h1>
 		<div class="ve-demo-editors">
 			<div class="ve-demo-editor">


### PR DESCRIPTION
This was happening because the buildLoader job was not being passed a
direction, so it was putting in both LTR and RTL styles and relying on
something to disable the RTL styles, but that wasn't happening.

Instead, pass dir: 'ltr' into buildLoader so that it only outputs the
LTR styles.