### PR TITLE
Add GoogleTranslator

### DIFF
--- a/build/modules.json
+++ b/build/modules.json
@@ -21,6 +21,7 @@
 			"src/ll.Translator.js",
 			"src/ll.ApertiumTranslator.js",
 			"src/ll.YandexTranslator.js",
+			"src/ll.GoogleTranslator.js",
 			"src/ll.Prism.js"
 		]
 	},

--- a/demo/LL.html
+++ b/demo/LL.html
@@ -100,6 +100,7 @@
 		<script src="../src/ll.Translator.js"></script>
 		<script src="../src/ll.ApertiumTranslator.js"></script>
 		<script src="../src/ll.YandexTranslator.js"></script>
+		<script src="../src/ll.GoogleTranslator.js"></script>
 		<script src="../src/ll.Prism.js"></script>
 
 		<script>

--- a/environment.json.google-example
+++ b/environment.json.google-example
@@ -1,0 +1,6 @@
+{
+	"translatorClass": "GoogleTranslator",
+	"translatorConfig": {
+		"key": "<PUT GOOGLE API KEY HERE>"
+	}
+}

--- a/src/ll.GoogleTranslator.js
+++ b/src/ll.GoogleTranslator.js
@@ -1,0 +1,131 @@
+/*!
+ * LL two-way parallel translation - Google translator class
+ *
+ * @copyright 2019 LL team and others; see LICENSE.txt for terms
+ */
+
+/**
+ * Google translator
+ * @abstract
+ * @class
+ *
+ * @constructor
+ * @param {Object} config
+ * @param {string} config.key API key
+ */
+ll.GoogleTranslator = function LLGoogleTranslator( config ) {
+	this.url = 'https://translation.googleapis.com';
+	if ( !config.key ) {
+		throw new Error( 'Need Google API key' );
+	}
+	this.key = config.key;
+	// Parent constructor: must be called after setting .url and .key above
+	ll.GoogleTranslator.super.call( this );
+};
+
+/* Initialization */
+
+OO.inheritClass( ll.GoogleTranslator, ll.Translator );
+
+// TODO: Make separators more robust.
+// Google messes with multi-character separators, usually by adding spaces betweem unalike character
+// repetitions, such as ":!!:" becoming ": !!:". Using more obscure characters works, but is still
+// inherently fragile.
+ll.GoogleTranslator.static.outerSeparator = '☆';
+ll.GoogleTranslator.static.innerSeparator = '️★';
+
+/**
+ * List of queued tasks.
+ * @static
+ * @type {Array}
+ */
+ll.GoogleTranslator.static.stack = [];
+
+/**
+ * Interval timer for processing the queue.
+ * @static
+ * @type {Array}
+ */
+ll.GoogleTranslator.static.timer = null;
+
+/**
+ * Process queued tasks.
+ *
+ * Clears the processing interval when the queue is empty.
+ */
+ll.GoogleTranslator.static.process = function () {
+	var task = this.stack.shift();
+	if ( this.stack.length === 0 ) {
+		task();
+		clearInterval( this.timer );
+		this.timer = null;
+	}
+};
+
+/**
+ * Queue tasks to be processed.
+ *
+ * Uses an interval timer (100ms) to rate-limit tasks.
+ * TODO: Consider moving this up to ll.Translator, as it seems generally useful.
+ *
+ * @param {Function} task Task function accepting resolve and reject functions as arguments
+ * @return {$.Promise} Promised task result or error
+ */
+ll.GoogleTranslator.static.queue = function ( task ) {
+	var deferred = $.Deferred();
+	this.stack.push( task.bind( null, deferred.resolve, deferred.reject ) );
+	if ( this.timer === null ) {
+		this.timer = setInterval( this.process.bind( ll.GoogleTranslator.static ), 100 );
+	}
+	return deferred.promise();
+};
+
+/* Instance methods */
+
+ll.GoogleTranslator.prototype.fetchLangPairsPromise = function () {
+	return $.ajax( {
+		url: this.url + '/language/translate/v2/languages',
+		datatype: 'json',
+		data: {
+			key: this.key
+		}
+	} ).then( function ( data ) {
+		var list = [];
+		data.data.languages.forEach( function ( source ) {
+			data.data.languages.forEach( function ( target ) {
+				if ( source !== target ) {
+					list.push( { source: source, target: target } );
+				}
+			} );
+		} );
+		return list;
+	} );
+};
+
+/**
+ * Translate plaintext
+ * @param {string} sourceLang Source language code
+ * @param {string} targetLang Target language code
+ * @param {string} text The text to translate
+ * @return {Promise} Promise resolving with the translated text
+ */
+ll.GoogleTranslator.prototype.translatePlaintext = function ( sourceLang, targetLang, text ) {
+	var translator = this;
+	return ll.GoogleTranslator.static.queue( function ( resolve, reject ) {
+		$.ajax( {
+			url: translator.url + '/language/translate/v2',
+			method: 'post',
+			datatype: 'json',
+			data: {
+				key: translator.key,
+				source: sourceLang,
+				target: targetLang,
+				q: text
+			}
+		} ).fail( function ( error ) {
+			reject( error );
+		} ).done( function ( data ) {
+			resolve( data.data.translations[ 0 ].translatedText );
+		} );
+	} );
+};

--- a/src/ll.GoogleTranslator.js
+++ b/src/ll.GoogleTranslator.js
@@ -44,7 +44,7 @@ ll.GoogleTranslator.static.stack = [];
 /**
  * Interval timer for processing the queue.
  * @static
- * @type {Array}
+ * @type {number|null}
  */
 ll.GoogleTranslator.static.timer = null;
 
@@ -54,8 +54,10 @@ ll.GoogleTranslator.static.timer = null;
  * Clears the processing interval when the queue is empty.
  */
 ll.GoogleTranslator.static.process = function () {
-	var task = this.stack.shift();
-	if ( this.stack.length === 0 ) {
+	var task = this.stack.pop();
+	// Remove the rest
+	this.stack.length = 0;
+	if ( task ) {
 		task();
 		clearInterval( this.timer );
 		this.timer = null;
@@ -75,7 +77,7 @@ ll.GoogleTranslator.static.queue = function ( task ) {
 	var deferred = $.Deferred();
 	this.stack.push( task.bind( null, deferred.resolve, deferred.reject ) );
 	if ( this.timer === null ) {
-		this.timer = setInterval( this.process.bind( ll.GoogleTranslator.static ), 100 );
+		this.timer = setInterval( this.process.bind( this ), 100 );
 	}
 	return deferred.promise();
 };

--- a/src/ll.Translator.js
+++ b/src/ll.Translator.js
@@ -44,6 +44,7 @@ ll.Translator.static.bundle = function ( groups ) {
  * @return {Array[]} Array of Arrays of strings
  */
 ll.Translator.static.unbundle = function ( bundled ) {
+	// TODO: Regex-escape the separator strings
 	var innerPattern = new RegExp( '\\s*' + this.innerSeparator + '\\s*' ),
 		outerPattern = new RegExp( '\\s*' + this.outerSeparator + '\\s*' );
 	return bundled.split( outerPattern ).map(

--- a/src/ll.Translator.js
+++ b/src/ll.Translator.js
@@ -21,6 +21,10 @@ OO.initClass( ll.Translator );
 
 /* Static methods */
 
+ll.Translator.static.outerSeparator = ':!!!:';
+
+ll.Translator.static.innerSeparator = ':!!:';
+
 /**
  * Bundle groups of strings for translation in one go
  *
@@ -29,8 +33,8 @@ OO.initClass( ll.Translator );
  */
 ll.Translator.static.bundle = function ( groups ) {
 	return groups.map( function ( group ) {
-		return group.join( '\n:!!:\n' );
-	} ).join( '\n:!!!:\n' );
+		return group.join( '\n' + this.innerSeparator + '\n' );
+	} ).join( '\n' + this.outerSeparator + '\n' );
 };
 
 /**
@@ -40,9 +44,13 @@ ll.Translator.static.bundle = function ( groups ) {
  * @return {Array[]} Array of Arrays of strings
  */
 ll.Translator.static.unbundle = function ( bundled ) {
-	return bundled.split( /\s*:!!!:\s*/ ).map( function ( groupString ) {
-		return groupString.split( /\s*:!!:\s*/ );
-	} );
+	var innerPattern = new RegExp( '\\s*' + this.innerSeparator + '\\s*' ),
+		outerPattern = new RegExp( '\\s*' + this.outerSeparator + '\\s*' );
+	return bundled.split( outerPattern ).map(
+		function ( groupString ) {
+			return groupString.split( innerPattern );
+		}
+	);
 };
 
 /* Instance methods */

--- a/tests/index.html
+++ b/tests/index.html
@@ -647,6 +647,7 @@
 		<script src="../src/ll.Translator.js"></script>
 		<script src="../src/ll.ApertiumTranslator.js"></script>
 		<script src="../src/ll.YandexTranslator.js"></script>
+		<script src="../src/ll.GoogleTranslator.js"></script>
 		<script src="../src/ll.Prism.js"></script>
 
 		<!-- ll.test -->


### PR DESCRIPTION
Had to use rate-limiting to overcome Google’s 10 requests per second hard limit. Also had to use different separators since Google tends to mess about with multi-character separators. This occurs even if they are sequences of obscure unicode characters, so it’s not related to any sort of valid punctuation translation.

Ask Trevor to borrow a key if you want to test it out, or get your own at https://console.developers.google.com/apis