### PR TITLE
Clean up environment messes

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@
 - `cd lib/ve`
 - `npm install`
 - `grunt build`
-- Download, install and run [Apertium-APy](https://github.com/apertium/apertium-apy) .
- (or alternatively, edit `demo/demo.ll.js` and change `http://localhost:2737/translate` to point to a public Apertium-APy instance)
+- `cp environment.json.apertium-example environment.json`
+ (or alternatively, use `environment.json.yandex-example` and put in your Yandex API key)
 - Run a local static webserver in the repository directory: `python3 -m http.server`
 - Browse to `http://localhost:8000/demo/LL.html`
 

--- a/demo/demo.ll.js
+++ b/demo/demo.ll.js
@@ -6,8 +6,8 @@
 
 ll.demo = {
 	/* eslint-disable no-jquery/no-global-selector */
-	$firstDemo: $( '.ve-demo-editor' ).eq( 0 ),
-	$secondDemo: $( '.ve-demo-editor' ).eq( 1 ),
+	$firstDemo: $( '.ll-demo-editor' ).eq( 0 ),
+	$secondDemo: $( '.ll-demo-editor' ).eq( 1 ),
 	$firstInstance: $( '.ve-instance' ).eq( 0 ),
 	$secondInstance: $( '.ve-instance' ).eq( 1 ),
 	translator: null
@@ -18,7 +18,7 @@ ll.demo.preload = function () {
 		.fail( function () {
 			ll.demo.$firstInstance.text(
 				'Could not load environment.json. ' +
-				'Be sure to make one using a copy of environment.json.example and modify as needed.'
+				'Be sure to make one using a copy of environment.json.apertium-example or environment.json.yandex-example and modify as needed.'
 			);
 		} )
 		.done( function ( env ) {


### PR DESCRIPTION
- Update jQuery selector for ve-demo-editor -> ll-demo-editor rename
 (this brings back the language selectors, which had disappeared)
- Refer to the correct example files in the error message we show
  when environment.json is missing
- Add environment.json instructions to README.md

Follow-up for 2c3c4e09bd4f2e8 and 230991bbf0cac13a.