### PR TITLE
Remove grunt commands from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,11 +9,9 @@
 - `git submodule update --init lib/ve`
 - Initialise and build the repository
 - `npm install`
-- `grunt`
 - Initialise and build the VE sub-module
 - `cd lib/ve`
 - `npm install`
-- `grunt build`
 - Download, install and run [Apertium-APy](https://github.com/apertium/apertium-apy) .
  (or alternatively, edit `demo/demo.ll.js` and change `http://localhost:2737/translate` to point to a public Apertium-APy instance)
 - Run a local static webserver in the repository directory: `python3 -m http.server`


### PR DESCRIPTION
In both repos, running npm install also runs grunt, so it doesn't need
to be run separately.