### PR TITLE
Use a CSS class for unsupported languages

### DIFF
--- a/demo/demo.ll.css
+++ b/demo/demo.ll.css
@@ -17,6 +17,10 @@
 	margin: 0 0 1em 0;
 }
 
+.ll-language-unsupported {
+	opacity: 0.5;
+}
+
 /* XXX should this be in ve.ce.ContentBranchNode.css? */
 .ve-ce-contentBranchNode-ll-dirty {
 	background-color: #fae168;

--- a/demo/demo.ll.js
+++ b/demo/demo.ll.js
@@ -73,9 +73,8 @@ ll.demo.setup = function () {
 							dir = ve.init.platform.getLanguageDirection( lang ),
 							surface = changedTarget.surface;
 						otherLangDropdown.getMenu().getItems().forEach( function ( j ) {
-							j.$element.css( 'opacity',
-								ll.demo.translator.pairSupported( langPairs, lang, j.getData() ) ?
-									1 : 0.5
+							j.$element.toggleClass( 'll-language-unsupported',
+								!ll.demo.translator.pairSupported( langPairs, lang, j.getData() )
 							);
 						} );
 						// This is ugly but you are unlikely to change language mid document.


### PR DESCRIPTION
Instead of hard-coding opacity changes in JS.

Follow-up to 528ff50d63a94b1b952070158451b2aad9160279.