### PR TITLE
Fix language dropdown when using Google Translate

### DIFF
--- a/src/ll.GoogleTranslator.js
+++ b/src/ll.GoogleTranslator.js
@@ -92,9 +92,12 @@ ll.GoogleTranslator.prototype.fetchLangPairsPromise = function () {
 			key: this.key
 		}
 	} ).then( function ( data ) {
-		var list = [];
-		data.data.languages.forEach( function ( source ) {
-			data.data.languages.forEach( function ( target ) {
+		var list = [],
+			languages = data.data.languages.map( function ( obj ) {
+				return obj.language;
+			} );
+		languages.forEach( function ( source ) {
+			languages.forEach( function ( target ) {
 				if ( source !== target ) {
 					list.push( { source: source, target: target } );
 				}


### PR DESCRIPTION
The code expected the data from the Google Translate API to look like:
    { source: 'en', target: 'nl' }
but it actually looks like:
    { source: { language: 'en' }, target: { language: 'nl' } }